### PR TITLE
Add ability to import global css via ?raw

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -261,6 +261,15 @@ module.exports = {
               importLoaders: 1,
             }),
           },
+          // Support `import 'react-select/main.css?raw;`
+          // https://github.com/css-modules/css-modules/pull/65#issuecomment-354712147
+          {
+            test: cssModuleRegex,
+            resourceQuery: /^\?raw$/,
+            use: getStyleLoaders({
+              importLoaders: 1,
+            }),
+          },
           // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
           // using the extension .module.css
           {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -347,6 +347,17 @@ module.exports = {
             // See https://github.com/webpack/webpack/issues/6571
             sideEffects: true,
           },
+          // Support `import 'react-select/main.css?raw;`
+          // https://github.com/css-modules/css-modules/pull/65#issuecomment-354712147
+          {
+            test: cssModuleRegex,
+            resourceQuery: /^\?raw$/,
+            loader: getStyleLoaders({
+              importLoaders: 1,
+              sourceMap: shouldUseSourceMap,
+            }),
+            sideEffects: true,
+          },
           // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
           // using the extension .module.css
           {


### PR DESCRIPTION
ex: `import './foo.css?raw'`
This is to allow importing CSS from shared npm packages without treating them as CSS modules