### PR TITLE
Fix issue with cloudfront invalidation errors

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -127,7 +127,9 @@ module.exports = {
     },
     // Keep the runtime chunk seperated to enable long term caching
     // https://twitter.com/wSokra/status/969679223278505985
-    runtimeChunk: true,
+    runtimeChunk: {
+      name: entrypoint => `runtime-${entrypoint.name}`
+    }
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -194,7 +194,9 @@ module.exports = {
     },
     // Keep the runtime chunk seperated to enable long term caching
     // https://twitter.com/wSokra/status/969679223278505985
-    runtimeChunk: true,
+    runtimeChunk: {
+      name: entrypoint => `runtime-${entrypoint.name}`
+    }
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.


### PR DESCRIPTION
This was caused by the runtime chunk having a tilde in the name, which needs to be URI encoded when sent via the AWS SDK, but gulp-cloudfront-invalidate-aws-publish does not do that. Instead, we just generate the filename with a `-` instead of `~`